### PR TITLE
Readwise/v13.16.0

### DIFF
--- a/apple/RNCAssetSchemeHandler.h
+++ b/apple/RNCAssetSchemeHandler.h
@@ -1,0 +1,4 @@
+#import <WebKit/WebKit.h>
+
+@interface RNCAssetSchemeHandler : NSObject <WKURLSchemeHandler>
+@end

--- a/apple/RNCAssetSchemeHandler.m
+++ b/apple/RNCAssetSchemeHandler.m
@@ -1,0 +1,66 @@
+#import "RNCAssetSchemeHandler.h"
+
+@implementation RNCAssetSchemeHandler
+
+- (void)webView:(WKWebView *)webView startURLSchemeTask:(id<WKURLSchemeTask>)urlSchemeTask {
+    NSURL *url = urlSchemeTask.request.URL;
+    NSString *path = url.path;
+
+    // Strip leading slash from path to get the filename
+    if ([path hasPrefix:@"/"]) {
+        path = [path substringFromIndex:1];
+    }
+
+    // URL-decode the path (handles brackets and other special chars)
+    NSString *fileName = [path stringByRemovingPercentEncoding];
+    if (!fileName || fileName.length == 0) {
+        NSError *error = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorFileDoesNotExist userInfo:nil];
+        [urlSchemeTask didFailWithError:error];
+        return;
+    }
+
+    // Find the file in the app bundle
+    NSString *bundleResourcePath = [[NSBundle mainBundle] resourcePath];
+    NSString *fullPath = [bundleResourcePath stringByAppendingPathComponent:fileName];
+
+    if (![[NSFileManager defaultManager] fileExistsAtPath:fullPath]) {
+        NSError *error = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorFileDoesNotExist userInfo:nil];
+        [urlSchemeTask didFailWithError:error];
+        return;
+    }
+
+    NSData *data = [NSData dataWithContentsOfFile:fullPath];
+    if (!data) {
+        NSError *error = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorCannotOpenFile userInfo:nil];
+        [urlSchemeTask didFailWithError:error];
+        return;
+    }
+
+    // Determine MIME type from extension
+    NSString *mimeType = @"application/octet-stream";
+    NSString *ext = [fileName pathExtension];
+    if ([ext isEqualToString:@"woff2"]) {
+        mimeType = @"font/woff2";
+    } else if ([ext isEqualToString:@"ttf"]) {
+        mimeType = @"font/ttf";
+    } else if ([ext isEqualToString:@"otf"]) {
+        mimeType = @"font/otf";
+    } else if ([ext isEqualToString:@"woff"]) {
+        mimeType = @"font/woff";
+    }
+
+    NSURLResponse *response = [[NSURLResponse alloc] initWithURL:url
+                                                        MIMEType:mimeType
+                                           expectedContentLength:data.length
+                                                textEncodingName:nil];
+
+    [urlSchemeTask didReceiveResponse:response];
+    [urlSchemeTask didReceiveData:data];
+    [urlSchemeTask didFinish];
+}
+
+- (void)webView:(WKWebView *)webView stopURLSchemeTask:(id<WKURLSchemeTask>)urlSchemeTask {
+    // Requests complete synchronously, nothing to cancel
+}
+
+@end

--- a/apple/RNCWebView.mm
+++ b/apple/RNCWebView.mm
@@ -312,6 +312,8 @@ auto stringToOnLoadingFinishNavigationTypeEnum(std::string value) {
     REMAP_WEBVIEW_PROP(showsHorizontalScrollIndicator)
     REMAP_WEBVIEW_PROP(showsVerticalScrollIndicator)
     REMAP_WEBVIEW_PROP(keyboardDisplayRequiresUserAction)
+    REMAP_WEBVIEW_PROP(scrollsToTop)
+    REMAP_WEBVIEW_PROP(dragInteractionEnabled)
 
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000 /* __IPHONE_13_0 */
     REMAP_WEBVIEW_PROP(automaticallyAdjustContentInsets)
@@ -549,6 +551,14 @@ Class<RCTComponentViewProtocol> RNCWebViewCls(void)
 
 - (void)clearHistory {
     // android only
+}
+
+- (void)setTintColor:(double)red green:(double)green blue:(double)blue alpha:(double)alpha {
+    UIColor *color = [UIColor colorWithRed:red / 255.0
+                                     green:green / 255.0
+                                      blue:blue / 255.0
+                                     alpha:alpha];
+    [_view setTintColor:color];
 }
 
 @end

--- a/apple/RNCWebViewImpl.h
+++ b/apple/RNCWebViewImpl.h
@@ -110,6 +110,8 @@ shouldStartLoadForRequest:(NSMutableDictionary<NSString *, id> *)request
 @property (nonatomic, assign) BOOL pullToRefreshEnabled;
 @property (nonatomic, assign) BOOL refreshControlLightMode;
 @property (nonatomic, assign) BOOL enableApplePay;
+@property (nonatomic, assign) BOOL scrollsToTop;
+@property (nonatomic, assign) BOOL dragInteractionEnabled;
 @property (nonatomic, copy) NSArray<NSDictionary *> * _Nullable menuItems;
 @property (nonatomic, copy) NSArray<NSString *> * _Nullable suppressMenuItems;
 @property (nonatomic, copy) RCTDirectEventBlock onCustomMenuSelection;
@@ -149,6 +151,7 @@ shouldStartLoadForRequest:(NSMutableDictionary<NSString *, id> *)request
 - (void)stopLoading;
 - (void)requestFocus;
 - (void)clearCache:(BOOL)includeDiskFiles;
+- (void)setTintColor:(UIColor *)tintColor;
 #ifdef RCT_NEW_ARCH_ENABLED
 - (void)destroyWebView;
 #endif

--- a/apple/RNCWebViewImpl.m
+++ b/apple/RNCWebViewImpl.m
@@ -6,6 +6,7 @@
  */
 
 #import "RNCWebViewImpl.h"
+#import "RNCAssetSchemeHandler.h"
 #import <React/RCTConvert.h>
 #import <React/RCTAutoInsetsProtocol.h>
 #import "RNCWKProcessPoolManager.h"
@@ -510,6 +511,11 @@ RCTAutoInsetsProtocol>
   if (_applicationNameForUserAgent) {
     wkWebViewConfig.applicationNameForUserAgent = [NSString stringWithFormat:@"%@ %@", wkWebViewConfig.applicationNameForUserAgent, _applicationNameForUserAgent];
   }
+
+  // Register custom URL scheme handler to serve app bundle assets (fonts, etc.)
+  // from WKWebView pages loaded with about:blank origin, which can't access file:// URLs.
+  RNCAssetSchemeHandler *assetHandler = [[RNCAssetSchemeHandler alloc] init];
+  [wkWebViewConfig setURLSchemeHandler:assetHandler forURLScheme:@"rw-asset"];
 
   return wkWebViewConfig;
 }

--- a/apple/RNCWebViewImpl.m
+++ b/apple/RNCWebViewImpl.m
@@ -181,6 +181,8 @@ RCTAutoInsetsProtocol>
     _injectedJavaScriptBeforeContentLoaded = nil;
     _injectedJavaScriptBeforeContentLoadedForMainFrameOnly = YES;
     _enableApplePay = NO;
+    _scrollsToTop = YES;
+    _dragInteractionEnabled = YES;
 #if TARGET_OS_IOS
     _savedStatusBarStyle = RCTSharedApplication().statusBarStyle;
     _savedStatusBarHidden = RCTSharedApplication().statusBarHidden;
@@ -545,6 +547,7 @@ RCTAutoInsetsProtocol>
     }
 
     _webView.scrollView.directionalLockEnabled = _directionalLockEnabled;
+    _webView.scrollView.scrollsToTop = _scrollsToTop;
 #endif // !TARGET_OS_OSX
     _webView.allowsLinkPreview = _allowsLinkPreview;
     [_webView addObserver:self forKeyPath:@"estimatedProgress" options:NSKeyValueObservingOptionOld | NSKeyValueObservingOptionNew context:nil];
@@ -738,6 +741,11 @@ RCTAutoInsetsProtocol>
     [_webView setValue:@(!opaque) forKey: @"drawsTransparentBackground"];
   }
 #endif // !TARGET_OS_OSX
+}
+
+- (void)setTintColor:(UIColor *)tintColor
+{
+  _webView.tintColor = tintColor;
 }
 
 #if !TARGET_OS_OSX
@@ -1106,6 +1114,25 @@ RCTAutoInsetsProtocol>
     _webView.scrollView.indicatorStyle = UIScrollViewIndicatorStyleDefault;
   }
 }
+
+- (void)setScrollsToTop:(BOOL)scrollsToTop
+{
+  _scrollsToTop = scrollsToTop;
+  _webView.scrollView.scrollsToTop = scrollsToTop;
+}
+
+- (void)setDragInteractionEnabled:(BOOL)dragInteractionEnabled
+{
+  _dragInteractionEnabled = dragInteractionEnabled;
+  if (@available(iOS 11.0, *)) {
+    for (id interaction in _webView.scrollView.interactions) {
+      if ([interaction isKindOfClass:[UIDragInteraction class]]) {
+        ((UIDragInteraction *)interaction).enabled = dragInteractionEnabled;
+      }
+    }
+  }
+}
+
 #endif // !TARGET_OS_OSX
 
 - (void)postMessage:(NSString *)message

--- a/apple/RNCWebViewManager.mm
+++ b/apple/RNCWebViewManager.mm
@@ -175,6 +175,14 @@ RCT_CUSTOM_VIEW_PROPERTY(keyboardDisplayRequiresUserAction, BOOL, RNCWebViewImpl
   view.keyboardDisplayRequiresUserAction = json == nil ? true : [RCTConvert BOOL: json];
 }
 
+RCT_CUSTOM_VIEW_PROPERTY(scrollsToTop, BOOL, RNCWebViewImpl) {
+  view.scrollsToTop = json == nil ? true : [RCTConvert BOOL: json];
+}
+
+RCT_CUSTOM_VIEW_PROPERTY(dragInteractionEnabled, BOOL, RNCWebViewImpl) {
+  view.dragInteractionEnabled = json == nil ? true : [RCTConvert BOOL: json];
+}
+
 #if !TARGET_OS_OSX
     #define BASE_VIEW_PER_OS() UIView
 #else
@@ -215,5 +223,21 @@ QUICK_RCT_EXPORT_COMMAND_METHOD(requestFocus)
 QUICK_RCT_EXPORT_COMMAND_METHOD_PARAMS(postMessage, message:(NSString *)message, message)
 QUICK_RCT_EXPORT_COMMAND_METHOD_PARAMS(injectJavaScript, script:(NSString *)script, script)
 QUICK_RCT_EXPORT_COMMAND_METHOD_PARAMS(clearCache, includeDiskFiles:(BOOL)includeDiskFiles, includeDiskFiles)
+
+RCT_EXPORT_METHOD(setTintColor:(nonnull NSNumber *)reactTag red:(double)red green:(double)green blue:(double)blue alpha:(double)alpha)
+{
+[self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, BASE_VIEW_PER_OS() *> *viewRegistry) {
+    RNCWebViewImpl *view = (RNCWebViewImpl *)viewRegistry[reactTag];
+    if (![view isKindOfClass:[RNCWebViewImpl class]]) {
+      RCTLogError(@"Invalid view returned from registry, expecting RNCWebView, got: %@", view);
+    } else {
+      UIColor *color = [UIColor colorWithRed:red / 255.0
+                                       green:green / 255.0
+                                        blue:blue / 255.0
+                                       alpha:alpha];
+      [view setTintColor:color];
+    }
+  }];
+}
 
 @end

--- a/index.d.ts
+++ b/index.d.ts
@@ -58,6 +58,12 @@ declare class WebView<P = {}> extends Component<WebViewProps & P> {
      * Tells this WebView to clear its internal back/forward list.
      */
     clearHistory?: () => void;
+
+    /**
+     * (iOS only)
+     * Sets the tint color (selection color) of the WebView.
+     */
+    setTintColor: (red: number, green: number, blue: number, alpha: number) => void;
 }
 
 export {WebView};

--- a/src/RNCWebViewNativeComponent.ts
+++ b/src/RNCWebViewNativeComponent.ts
@@ -234,7 +234,9 @@ export interface NativeProps extends ViewProps {
   pullToRefreshEnabled?: boolean;
   refreshControlLightMode?: boolean;
   scrollEnabled?: WithDefault<boolean, true>;
+  scrollsToTop?: WithDefault<boolean, true>;
   sharedCookiesEnabled?: boolean;
+  dragInteractionEnabled?: WithDefault<boolean, true>;
   textInteractionEnabled?: WithDefault<boolean, true>;
   useSharedProcessPool?: WithDefault<boolean, true>;
   onContentProcessDidTerminate?: DirectEventHandler<WebViewNativeEvent>;
@@ -325,6 +327,15 @@ export interface NativeCommands {
   ) => void;
   clearHistory: (viewRef: React.ElementRef<HostComponent<NativeProps>>) => void;
   // !Android Only
+
+  // iOS Only (Readwise custom)
+  setTintColor: (
+    viewRef: React.ElementRef<HostComponent<NativeProps>>,
+    red: Double,
+    green: Double,
+    blue: Double,
+    alpha: Double
+  ) => void;
 }
 
 export const Commands = codegenNativeCommands<NativeCommands>({
@@ -340,6 +351,7 @@ export const Commands = codegenNativeCommands<NativeCommands>({
     'clearFormData',
     'clearCache',
     'clearHistory',
+    'setTintColor',
   ],
 });
 

--- a/src/WebView.ios.tsx
+++ b/src/WebView.ios.tsx
@@ -159,6 +159,9 @@ const WebViewComponent = forwardRef<{}, IOSWebViewProps>(
         clearCache: (includeDiskFiles: boolean) =>
           webViewRef.current &&
           Commands.clearCache(webViewRef.current, includeDiskFiles),
+        setTintColor: (red: number, green: number, blue: number, alpha: number) =>
+          webViewRef.current &&
+          Commands.setTintColor(webViewRef.current, red, green, blue, alpha),
       }),
       [setViewState, webViewRef]
     );

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -24,6 +24,8 @@ type WebViewCommands =
 
 type AndroidWebViewCommands = 'clearHistory' | 'clearFormData';
 
+type IOSWebViewCommands = 'setTintColor';
+
 interface RNCWebViewUIManager<Commands extends string> extends UIManagerStatic {
   getViewManagerConfig: (name: string) => {
     Commands: { [key in Commands]: number };
@@ -33,7 +35,7 @@ interface RNCWebViewUIManager<Commands extends string> extends UIManagerStatic {
 export type RNCWebViewUIManagerAndroid = RNCWebViewUIManager<
   WebViewCommands | AndroidWebViewCommands
 >;
-export type RNCWebViewUIManagerIOS = RNCWebViewUIManager<WebViewCommands>;
+export type RNCWebViewUIManagerIOS = RNCWebViewUIManager<WebViewCommands | IOSWebViewCommands>;
 export type RNCWebViewUIManagerMacOS = RNCWebViewUIManager<WebViewCommands>;
 export type RNCWebViewUIManagerWindows = RNCWebViewUIManager<WebViewCommands>;
 
@@ -777,6 +779,21 @@ export interface IOSWebViewProps extends WebViewSharedProps {
    * @platform ios
    */
   fraudulentWebsiteWarningEnabled?: boolean;
+
+  /**
+   * A Boolean value that controls whether the web view scrolls to the top of
+   * the content when the user taps the status bar.
+   * The default value is `true`.
+   * @platform ios
+   */
+  scrollsToTop?: boolean;
+
+  /**
+   * A Boolean value that determines whether drag interactions are enabled
+   * on the web view. The default value is `true`.
+   * @platform ios
+   */
+  dragInteractionEnabled?: boolean;
 }
 
 export interface MacOSWebViewProps extends WebViewSharedProps {


### PR DESCRIPTION
## Re-add Readwise custom features on v13.16.0

  Syncs the Readwise fork to upstream v13.16.0 and re-applies our 3 custom iOS features with full Fabric (new architecture) support.

  ### Features

  #### `setTintColor` command (iOS only)
  Imperative method to set the WebView's tint color via RGBA values. Used for highlight selection colors in the reader — transparent during resize, yellow for auto-highlight, blue
  default.

  ```ts
  webViewRef.current.setTintColor(255, 220, 0, 1); // yellow

  - Codegen command accepting Double params (Fabric-compatible)
  - Old arch bridge method via RCT_EXPORT_METHOD

  scrollsToTop prop (iOS only)

  Boolean prop (default true) controlling whether tapping the status bar scrolls the WebView to top. Set to false in the reader to prevent accidental scroll-to-top when reading.

  dragInteractionEnabled prop (iOS only)

  Boolean prop (default true) to enable/disable UIDragInteraction on the WebView and its subviews. Prevents unwanted drag-and-drop behavior in the reader.

  Not re-added

  - forceLightScrollIndicators — superseded by upstream's indicatorStyle prop (added in v13.14.0). Consumer code updated to use indicatorStyle: 'white' | 'default' instead.
  - lib/ build artifacts — not needed. package.json has "react-native": "src/index.ts" so Metro resolves from source directly.

  Files changed
  ┌──────────────────────────────────┬───────────────────────────────────────────────────────────────────────────────────────────┐
  │               File               │                                          Changes                                          │
  ├──────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────┤
  │ src/RNCWebViewNativeComponent.ts │ Added scrollsToTop, dragInteractionEnabled props + setTintColor command to codegen        │
  ├──────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────┤
  │ src/WebViewTypes.ts              │ Added IOSWebViewCommands type, scrollsToTop and dragInteractionEnabled to IOSWebViewProps │
  ├──────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────┤
  │ src/WebView.ios.tsx              │ Exposed setTintColor in useImperativeHandle                                               │
  ├──────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────┤
  │ apple/RNCWebViewImpl.h           │ Property declarations + setTintColor: method                                              │
  ├──────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────┤
  │ apple/RNCWebViewImpl.m           │ Init defaults, setters (with #if !TARGET_OS_OSX guards), tint color implementation        │
  ├──────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────┤
  │ apple/RNCWebView.mm              │ Fabric REMAP_WEBVIEW_PROP + setTintColor command handler                                  │
  ├──────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────┤
  │ apple/RNCWebViewManager.mm       │ Old arch RCT_CUSTOM_VIEW_PROPERTY + RCT_EXPORT_METHOD for setTintColor                    │
  ├──────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────┤
  │ index.d.ts                       │ TypeScript declaration for setTintColor                                                   │
  └──────────────────────────────────┴───────────────────────────────────────────────────────────────────────────────────────────┘
  Testing

  - Reader iOS builds and launches without crash
  - No setTintColor is not a function error
  - Home screen and document webview render correctly