### PR TITLE
Add Android no-op stubs for iOS-only codegen props

### DIFF
--- a/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -428,6 +428,15 @@ public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper>
 
     @Override
     public void setFraudulentWebsiteWarningEnabled(RNCWebViewWrapper view, boolean value) {}
+
+    @Override
+    public void setTintColor(RNCWebViewWrapper view, double r, double g, double b, double a) {}
+
+    @Override
+    public void setScrollsToTop(RNCWebViewWrapper view, boolean value) {}
+
+    @Override
+    public void setDragInteractionEnabled(RNCWebViewWrapper view, boolean value) {}
     /* !iOS PROPS - no implemented here */
 
     @Override


### PR DESCRIPTION
Commit 010b9de added scrollsToTop, dragInteractionEnabled, and setTintColor to the codegen spec (RNCWebViewNativeComponent.ts) but only implemented them on iOS. Codegen generates a single Java interface for all platforms, so Android fails to compile without these stubs.