### PR TITLE
Fix Android crash: null menu items in setMenuCustomItems

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
@@ -642,9 +642,12 @@ class RNCWebViewManagerImpl {
       }
     }
 
-    fun setMenuCustomItems(viewWrapper: RNCWebViewWrapper, value: ReadableArray) {
+    fun setMenuCustomItems(viewWrapper: RNCWebViewWrapper, value: ReadableArray?) {
         val view = viewWrapper.webView
-        view.setMenuCustomItems(value.toArrayList() as List<Map<String, String>>)
+        when (value) {
+            null -> view.setMenuCustomItems(null)
+            else -> view.setMenuCustomItems(value.toArrayList() as List<Map<String, String>>)
+        }
     }
 
     fun setNestedScrollEnabled(viewWrapper: RNCWebViewWrapper, value: Boolean) {


### PR DESCRIPTION
## Summary
Fixes https://readwise.sentry.io/issues/7264617792/events/?project=4507419919450112&query=&referrer=issue-stream

Cherry-pick of upstream fix https://github.com/react-native-webview/react-native-webview/pull/3375

`setMenuCustomItems` in `RNCWebViewManagerImpl.kt` declares its `value` parameter as non-null `ReadableArray`, but Android passes `null` when there are no custom menu items configured. This causes a `NullPointerException` crash when users make large text selections.

**Fix**: Changed parameter to nullable `ReadableArray?` with a `when` null check.

## Context
This crash was discovered during the Bookwise Android security audit — it prevented testing highlight behavior. The fix already exists on `main` (commit ccefcf1) but the Bookwise app pins commit 8676dcac which predates it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes RW-44181