### PR TITLE
Add Android no-op stub for preventUniversalLinks

### DIFF
--- a/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -437,6 +437,9 @@ public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper>
 
     @Override
     public void setDragInteractionEnabled(RNCWebViewWrapper view, boolean value) {}
+
+    @Override
+    public void setPreventUniversalLinks(RNCWebViewWrapper view, @Nullable ReadableArray value) {}
     /* !iOS PROPS - no implemented here */
 
     @Override


### PR DESCRIPTION
## Summary

PR #10 added `preventUniversalLinks` to the codegen spec (`src/RNCWebViewNativeComponent.ts`) with iOS-only implementation. RN codegen emits a single `RNCWebViewManagerInterface` for both platforms, so Android fails to compile:

```
error: RNCWebViewManager is not abstract and does not override
abstract method setPreventUniversalLinks(RNCWebViewWrapper, ReadableArray)
in RNCWebViewManagerInterface
```

This adds a no-op stub in the newarch Android manager, mirroring the existing pattern (b3919a9: `setBounces`, `setLimitsNavigationsToAppBoundDomains`, `setTintColor`, `setScrollsToTop`, `setDragInteractionEnabled`).

## Test plan

- [ ] Bookwise Android EAS build succeeds at `:react-native-webview:compileReleaseJavaWithJavac`

🤖 Generated with [Claude Code](https://claude.com/claude-code)